### PR TITLE
Add remote session sharing example

### DIFF
--- a/codex-cli/bin/codexzipus.js
+++ b/codex-cli/bin/codexzipus.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'url';
+import path from 'path';
+
+const cliPath = path.resolve(__dirname, '../dist/remote-session.js');
+const cliUrl = pathToFileURL(cliPath).href;
+
+(async () => {
+  try {
+    await import(cliUrl);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/codex-cli/build.mjs
+++ b/codex-cli/build.mjs
@@ -69,20 +69,31 @@ if (isDevBuild) {
   plugins.push(devShebangPlugin);
 }
 
-esbuild
-  .build({
-    entryPoints: ["src/cli.tsx"],
-    // Do not bundle the contents of package.json at build time: always read it
-    // at runtime.
-    external: ["../package.json"],
-    bundle: true,
-    format: "esm",
-    platform: "node",
-    tsconfig: "tsconfig.json",
+const builds = [
+  {
+    entry: "src/cli.tsx",
     outfile: isDevBuild ? `${OUT_DIR}/cli-dev.js` : `${OUT_DIR}/cli.js`,
-    minify: !isDevBuild,
-    sourcemap: isDevBuild ? "inline" : true,
-    plugins,
-    inject: ["./require-shim.js"],
-  })
-  .catch(() => process.exit(1));
+  },
+  {
+    entry: "src/remote-session.ts",
+    outfile: `${OUT_DIR}/remote-session.js`,
+  },
+];
+
+Promise.all(
+  builds.map((cfg) =>
+    esbuild.build({
+      entryPoints: [cfg.entry],
+      external: ["../package.json"],
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      tsconfig: "tsconfig.json",
+      outfile: cfg.outfile,
+      minify: !isDevBuild,
+      sourcemap: isDevBuild ? "inline" : true,
+      plugins,
+      inject: ["./require-shim.js"],
+    })
+  )
+).catch(() => process.exit(1));

--- a/codex-cli/examples/remote-session/README.md
+++ b/codex-cli/examples/remote-session/README.md
@@ -7,8 +7,9 @@ User input from the web page is forwarded to the Codex process.
 ## Usage
 
 1. Install dependencies (`pnpm install`) if you haven't already.
-2. Run `./run.sh` to start the server.
-3. Open `http://localhost:3000` in your browser.
+2. Build the CLI: `pnpm run build`.
+3. Launch the server from any directory with `codexzipus`.
+4. Open `http://localhost:3000` in your browser.
 
 To share the session publicly you can create a tunnel with a tool like
 [ngrok](https://ngrok.com/):

--- a/codex-cli/examples/remote-session/README.md
+++ b/codex-cli/examples/remote-session/README.md
@@ -1,0 +1,21 @@
+# Remote Codex Session
+
+This example exposes a running Codex session over HTTP. It starts a small web
+server that spawns a Codex process and streams the output to connected clients.
+User input from the web page is forwarded to the Codex process.
+
+## Usage
+
+1. Install dependencies (`pnpm install`) if you haven't already.
+2. Run `./run.sh` to start the server.
+3. Open `http://localhost:3000` in your browser.
+
+To share the session publicly you can create a tunnel with a tool like
+[ngrok](https://ngrok.com/):
+
+```bash
+ngrok http 3000
+```
+
+Share the generated URL with collaborators. They will see the same Codex session
+in their browser and can type commands in the input box.

--- a/codex-cli/examples/remote-session/public/index.html
+++ b/codex-cli/examples/remote-session/public/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Codex Remote Session</title>
+  <style>
+    body { font-family: monospace; background: #000; color: #0f0; }
+    #output { white-space: pre-wrap; background: #111; padding: 8px; height: 70vh; overflow-y: auto; }
+    #input { width: 100%; box-sizing: border-box; }
+  </style>
+</head>
+<body>
+  <div id="output"></div>
+  <form id="form">
+    <input id="input" autocomplete="off" autofocus />
+  </form>
+  <script>
+    const output = document.getElementById('output');
+    const input = document.getElementById('input');
+    const form = document.getElementById('form');
+    const evt = new EventSource('/stream');
+    evt.onmessage = e => {
+      output.textContent += e.data + '\n';
+      output.scrollTop = output.scrollHeight;
+    };
+    form.onsubmit = async (e) => {
+      e.preventDefault();
+      await fetch('/input', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: input.value + '\n' })
+      });
+      input.value = '';
+    };
+  </script>
+</body>
+</html>

--- a/codex-cli/examples/remote-session/run.sh
+++ b/codex-cli/examples/remote-session/run.sh
@@ -3,4 +3,4 @@
 
 dir="$(cd "$(dirname "$0")" && pwd)"
 cd "$dir" || exit 1
-node server.js
+codexzipus

--- a/codex-cli/examples/remote-session/run.sh
+++ b/codex-cli/examples/remote-session/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Simple script to launch the remote Codex session server
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$dir" || exit 1
+node server.js

--- a/codex-cli/examples/remote-session/server.js
+++ b/codex-cli/examples/remote-session/server.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+const clients = new Set();
+
+app.get('/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+  clients.add(res);
+  req.on('close', () => {
+    clients.delete(res);
+  });
+});
+
+function broadcast(data) {
+  for (const client of clients) {
+    client.write(`data: ${data.replace(/\n/g, '\n')}\n\n`);
+  }
+}
+
+const shell = spawn('script', ['-qfc', 'codex', '/dev/null']);
+
+shell.stdout.on('data', (data) => broadcast(data.toString()));
+shell.stderr.on('data', (data) => broadcast(data.toString()));
+shell.on('close', (code) => broadcast(`\nProcess exited with code ${code}\n`));
+
+app.post('/input', (req, res) => {
+  if (req.body && typeof req.body.data === 'string') {
+    shell.stdin.write(req.body.data);
+  }
+  res.status(204).end();
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "bin/codex.js"
+    "codex": "bin/codex.js",
+    "codexzipus": "bin/codexzipus.js"
   },
   "type": "module",
   "engines": {

--- a/codex-cli/src/remote-session.ts
+++ b/codex-cli/src/remote-session.ts
@@ -1,0 +1,52 @@
+import express from 'express';
+import { spawn } from 'child_process';
+
+const port = process.env.PORT || 3000;
+const app = express();
+
+const INDEX_HTML = `<!doctype html><html><head><meta charset="utf-8" />
+<title>Codex Remote Session</title>
+<style>body{font-family:monospace;background:#000;color:#0f0;}#output{white-space:pre-wrap;background:#111;padding:8px;height:70vh;overflow-y:auto;}#input{width:100%;box-sizing:border-box;}</style>
+</head><body><div id="output"></div><form id="form"><input id="input" autocomplete="off" autofocus /></form>
+<script>const output=document.getElementById('output');const input=document.getElementById('input');const form=document.getElementById('form');const evt=new EventSource('/stream');evt.onmessage=e=>{output.textContent+=e.data+'\n';output.scrollTop=output.scrollHeight;};form.onsubmit=async e=>{e.preventDefault();await fetch('/input',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({data:input.value+'\n'})});input.value='';};</script></body></html>`;
+
+app.use(express.json());
+
+app.get('/', (_req, res) => {
+  res.type('html').send(INDEX_HTML);
+});
+
+const clients = new Set<express.Response>();
+
+app.get('/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+  clients.add(res);
+  req.on('close', () => clients.delete(res));
+});
+
+function broadcast(data: string) {
+  for (const client of clients) {
+    client.write(`data: ${data.replace(/\n/g, '\n')}\n\n`);
+  }
+}
+
+const shell = spawn('script', ['-qfc', 'codex', '/dev/null'], { cwd: process.cwd() });
+
+shell.stdout.on('data', (d) => broadcast(d.toString()));
+shell.stderr.on('data', (d) => broadcast(d.toString()));
+shell.on('close', (code) => broadcast(`\nProcess exited with code ${code}\n`));
+
+app.post('/input', (req, res) => {
+  if (req.body && typeof req.body.data === 'string') {
+    shell.stdin.write(req.body.data);
+  }
+  res.status(204).end();
+});
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add `remote-session` example with a tiny Express server
- serve a minimal webpage that streams Codex output via SSE
- document how to launch and expose the session with ngrok

## Testing
- `pnpm test` *(fails: request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm run lint` *(fails: request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm run typecheck` *(fails: request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68447159a950832aab95ba58ef5bd0e2