### PR TITLE
Add remote web session option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ That's it - Codex will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
 
+### Remote session mode
+
+Run a web server to interact with Codex from your browser:
+
+```shell
+codex --remote-session --port 3000
+```
+
+This launches a local website at `http://localhost:3000` (or the port you
+specify) and lets you send prompts and view results without leaving the
+terminal.
+
 ---
 
 ## Why Codex?
@@ -221,6 +233,7 @@ The hardening mechanism Codex uses depends on your OS:
 | `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
 | `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
+| `codex --remote-session`            | Start web server for remote use     | `codex --remote-session --port 4000` |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -28,6 +28,7 @@ import type { ReasoningEffort } from "openai/resources.mjs";
 import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
 import SessionsOverlay from "./components/sessions-overlay.js";
+import REMOTE_HTML from "./remote-html";
 import { AgentLoop } from "./utils/agent/agent-loop";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
@@ -48,12 +49,15 @@ import { parseToolCall } from "./utils/parsers";
 import { onExit, setInkRenderer } from "./utils/terminal";
 import chalk from "chalk";
 import { spawnSync } from "child_process";
+import express from "express";
 import fs from "fs";
 import { render } from "ink";
 import meow from "meow";
+import open from "open";
 import os from "os";
 import path from "path";
 import React from "react";
+import { fileURLToPath } from "url";
 
 // Call this early so `tail -F "$TMPDIR/oai-codex/codex-cli-latest.log"` works
 // immediately. This must be run with DEBUG=1 for logging to work.
@@ -101,6 +105,9 @@ const cli = meow(
                               with models o3 and o4-mini)
 
     --reasoning <effort>      Set the reasoning effort level (low, medium, high) (default: high)
+
+    --remote-session          Start a local web server for remote interaction
+    --port <port>             Port for the web server (default: 3000)
 
   Dangerous options
     --dangerously-auto-approve-everything
@@ -192,6 +199,14 @@ const cli = meow(
         description: "Set the reasoning effort level (low, medium, high)",
         choices: ["low", "medium", "high"],
         default: "high",
+      },
+      remoteSession: {
+        type: "boolean",
+        description: "Start a local web server for remote interaction",
+      },
+      port: {
+        type: "string",
+        description: "Port for the web server (default: 3000)",
       },
       // Notification
       notify: {
@@ -292,6 +307,34 @@ let prompt = cli.input[0];
 const model = cli.flags.model ?? config.model;
 const imagePaths = cli.flags.image;
 const provider = cli.flags.provider ?? config.provider ?? "openai";
+
+if (cli.flags.remoteSession) {
+  const port = Number(cli.flags.port ?? 3000);
+  const app = express();
+  app.use(express.json());
+  app.get("/", (_req, res) => {
+    res.type("html").send(REMOTE_HTML);
+  });
+  app.post("/run", (req, res) => {
+    const promptText = req.body?.prompt;
+    if (!promptText) {
+      res.status(400).json({ error: "Missing prompt" });
+      return;
+    }
+    const cliPath = fileURLToPath(import.meta.url);
+    const child = spawnSync(process.execPath, [cliPath, "-q", promptText], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    res.json({ output: child.stdout + child.stderr });
+  });
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Codex web server running on http://localhost:${port}`);
+    open(`http://localhost:${port}`);
+  });
+  await new Promise(() => {});
+}
 
 const client = {
   issuer: "https://auth.openai.com",

--- a/codex-cli/src/remote-html.ts
+++ b/codex-cli/src/remote-html.ts
@@ -1,0 +1,26 @@
+export default `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Codex Web</title>
+<style>
+body { font-family: sans-serif; margin: 2rem; }
+textarea { width: 100%; height: 150px; }
+pre { background:#f0f0f0; padding:1rem; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<h1>Codex Web</h1>
+<textarea id="prompt" placeholder="Enter your prompt here"></textarea><br>
+<button id="run">Run</button>
+<pre id="output"></pre>
+<script>
+document.getElementById('run').onclick = async () => {
+  const prompt = (document.getElementById('prompt') as HTMLTextAreaElement).value;
+  const res = await fetch('/run', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({prompt})});
+  const data = await res.json();
+  (document.getElementById('output') as HTMLElement).textContent = data.output;
+};
+</script>
+</body>
+</html>`;


### PR DESCRIPTION
## Summary
- add `--remote-session` flag to start a simple Express web server
- expose `--port` option
- document remote session usage in README
- add minimal HTML front-end for the remote server

## Testing
- `pnpm install`
- `pnpm build`
- `pnpm test` *(fails: TerminalChatInput file tag suggestion)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684477ac0f10832a9b8a077585d3ba60